### PR TITLE
use state_beacon ‎️‍🔥 for http page‎️‍

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flsigs/screens/counter_screen.dart';
-import 'package:flsigs/screens/http_screen.dart';
+import 'package:flsigs/screens/http_screen_state_beacon.dart';
 import 'package:flsigs/screens/todo_screen.dart';
 import 'package:flutter/material.dart';
 
@@ -21,7 +21,7 @@ class HomeScreen extends StatelessWidget {
         ),
         _NavItem(
           label: "Http",
-          screen: HttpScreen(),
+          screen: HttpScreenBeacon(),
         )
       ]),
     );

--- a/lib/screens/http_screen_state_beacon.dart
+++ b/lib/screens/http_screen_state_beacon.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:state_beacon/state_beacon.dart';
+
+const apiUrl =
+    "https://v2.jokeapi.dev/joke/Programming?type=twopart&blacklistFlags=nsfw,religious,political,racist,sexist,explicit";
+
+typedef Joke = ({String setup, String delivery});
+
+final beacon = Beacon.future(() => getJoke(), manualStart: true);
+
+Future<Joke> getJoke() async {
+  final response = await http.get(Uri.parse(apiUrl));
+  final data = jsonDecode(response.body);
+
+  if (data['error'] == true) {
+    throw Exception("Error");
+  }
+
+  final Joke joke = (setup: data['setup'], delivery: data['delivery']);
+
+  return joke;
+}
+
+class HttpScreenBeacon extends StatelessWidget {
+  const HttpScreenBeacon({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Http"),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            IconButton(
+              onPressed: () {
+                if (beacon.isIdle) {
+                  beacon.start();
+                } else {
+                  beacon.reset();
+                }
+              },
+              icon: Icon(Icons.refresh),
+            ),
+            Builder(builder: (context) {
+              return switch (beacon.watch(context)) {
+                AsyncIdle _ => Text("Tap the button to load a joke!"),
+                AsyncLoading _ => Center(child: CircularProgressIndicator()),
+                AsyncError data => Center(child: Text(data.error.toString())),
+                AsyncData<Joke> data => Text(
+                    "${data.value.setup}\n\n${data.value.delivery}",
+                    textAlign: TextAlign.center,
+                  ),
+              };
+            }),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -176,6 +176,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.11.1"
+  state_beacon:
+    dependency: "direct main"
+    description:
+      name: state_beacon
+      sha256: df79d2360271e377eb4d9c75a77628da5e57e769efbf9d551cfe7e1b406de838
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.30.1"
+  state_beacon_core:
+    dependency: transitive
+    description:
+      name: state_beacon_core
+      sha256: "66ae38a89d1401062d64bedc5099796b7742c134e1617a5504a612b66d42f8b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.30.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  state_beacon: ^0.30.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Hey, I watched your video and thought I would try to implement the http page with my signals library: [state_beacon](https://pub.dev/packages/state_beacon). 

I think it's nicer as you don't have to set errors manually or deal with nulls. Let me know what you think.